### PR TITLE
Remove Slack as a support mean

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ to build and install the generated extension.
 ## 💬Support and Community
 
 If you do get enough interest to build a Docker Extension, the team at Docker is available to support you.
-You can find us in the [Docker Community Slack](http://dockr.ly/slack) in #extensions, post issues on our [SDK repo](https://github.com/docker/extensions-sdk), or reach us via email extensions(AT)docker.com.
+You can find us in the [Docker Forum](https://forums.docker.com/t/about-the-hacktoberfest-category/129061), post issues on our [SDK repo](https://github.com/docker/extensions-sdk), or reach us via email extensions(AT)docker.com.
 
 ## References:
 


### PR DESCRIPTION
Included the Docker Forum instead