### PR TITLE
Fixes the URL link for Extension lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ We know that creating your own extension can feel like a big undertaking so here
 2. The extension does not need to be production ready by the end of Hacktoberfest.
 3. The extension could be an idea or proof of concept.
 
-## ✔️List of Docker Extensions for Hacktoberfest 2022
+## List of Docker Extensions for Hacktoberfest 2022
 
 Here is a list of Docker Extension repos you can contribute to, part of the Hacktoberfest event.
 


### PR DESCRIPTION
Currently, the direct link to access the list of Extension shows weird characters. It would be better to keep it simple.

<img width="953" alt="image" src="https://user-images.githubusercontent.com/313480/193278867-0b08c635-18c3-47d0-abed-f765f9026067.png">


Also, let's not forgot to update the same link under the main hactoberfest site too

<img width="821" alt="image" src="https://user-images.githubusercontent.com/313480/193278807-73111b84-4c06-49e0-b1fa-72436b3b1012.png">
