### PR TITLE
Add Graph View extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ You can add your own extension in this list with your own github repository.
 | [Calyptia Core](https://github.com/calyptia/core-docker-desktop-extension)                | Observability             | Community      | ✅          |
 | [Percona Monitoring and Management](https://github.com/edithturn/pmm-docker-extension)    | Database Monitoring       | Community      | ✅          |
 | [LocalStack](https://github.com/localstack/localstack-docker-extension)                   | Cloud Emulator            | Community      | ✅          |
+| [Graph View](https://github.com/lucbpz/graph-view-docker-extension)                       | Utility                   | Community      | ✅          |
 | Add new extension to participate                                                          |                           |                |             |
 
 ## List of Docker Extensions suggestions


### PR DESCRIPTION
Adds Graph View extension

## What does this extension do?

- See your Docker containers, images and volumes in a network graph.

![screenshot](https://github.com/lucbpz/graph-view-docker-extension/blob/main/screenshots/network-graph.gif?raw=true)